### PR TITLE
Add Firebase Analytics for visit and click tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,15 @@ Experience content comes from `resume/jd.pdf` — Swiftly, Mode, BodyBuilding.co
 - Every icon-only button must have an `aria-label` (use `data-i18n-attr` so it's translated).
 - Use the existing `:focus-visible` ring — don't disable outlines.
 
+## Analytics
+
+Firebase Analytics (GA4 backend) is loaded via the **compat CDN** (v11.6.0) — two `<script defer>` tags in `index.html` before `custom.js`. Firebase project: **jdgarita-site** (Firebase Console: `console.firebase.google.com/project/jdgarita-site`).
+
+- Initialization and the `logEvent` helper live in `js/custom.js` inside the IIFE, guarded by `typeof firebase !== 'undefined'` so the site degrades gracefully if the SDK is blocked (ad blockers, `file://`).
+- Pageviews are tracked automatically on init.
+- Custom events: `file_download` (resume), `select_content` (nav sections, contact links, store link), `theme_toggle`, `lang_toggle`, `mobile_nav_toggle`.
+- The Firebase web API key is safe to commit — it's restricted by domain, not a secret.
+
 ## Icons
 
 FontAwesome 4.7.0 covers almost everything (`fa-github`, `fa-linkedin`, `fa-apple`, `fa-envelope`, `fa-bars`, `fa-moon-o` / `fa-sun-o`, etc.). **`fa-google-play` does not exist in the FA4 line** — not even 4.7.0. The Google Play button uses an inline SVG path (from Simple Icons) that inherits `currentColor`. If you need another brand icon that FA4 lacks, follow the same inline-SVG pattern rather than upgrading the icon library.

--- a/index.html
+++ b/index.html
@@ -341,6 +341,10 @@
         </div>
     </footer>
 
+    <!-- Firebase Analytics (compat CDN — no bundler needed) -->
+    <script defer src="https://www.gstatic.com/firebasejs/11.6.0/firebase-app-compat.js"></script>
+    <script defer src="https://www.gstatic.com/firebasejs/11.6.0/firebase-analytics-compat.js"></script>
+
     <script src="js/custom.js"></script>
 </body>
 </html>

--- a/js/custom.js
+++ b/js/custom.js
@@ -166,6 +166,12 @@
         }
     };
 
+    /* ---------- Firebase Analytics ---------- */
+    var analytics = null;
+    function logEvent(name, params) {
+        if (analytics) { try { analytics.logEvent(name, params); } catch (e) {} }
+    }
+
     /* ---------- Helpers ---------- */
     function $(sel, root) { return (root || document).querySelector(sel); }
     function $$(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
@@ -218,6 +224,22 @@
 
     /* ---------- Boot ---------- */
     document.addEventListener('DOMContentLoaded', function () {
+        // Firebase init (deferred SDK scripts have executed by now)
+        if (typeof firebase !== 'undefined' && firebase.initializeApp) {
+            try {
+                firebase.initializeApp({
+                    apiKey: 'AIzaSyB4OruGxSx4X-AV9OOcwRULNcharw6kNuw',
+                    authDomain: 'jdgarita-site.firebaseapp.com',
+                    projectId: 'jdgarita-site',
+                    storageBucket: 'jdgarita-site.firebasestorage.app',
+                    messagingSenderId: '319136318898',
+                    appId: '1:319136318898:web:88b2842ffefa0e20c250ab',
+                    measurementId: 'G-NYVB5C810D'
+                });
+                analytics = firebase.analytics();
+            } catch (e) {}
+        }
+
         // Initial language (the inline head script already set <html lang>)
         var lang = document.documentElement.getAttribute('lang') || 'en';
         if (lang !== 'en' && lang !== 'es') lang = 'en';
@@ -228,7 +250,9 @@
         if (themeBtn) {
             themeBtn.addEventListener('click', function () {
                 var current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
-                setTheme(current === 'dark' ? 'light' : 'dark');
+                var next = current === 'dark' ? 'light' : 'dark';
+                setTheme(next);
+                logEvent('theme_toggle', { theme: next });
             });
         }
 
@@ -237,7 +261,9 @@
         if (langBtn) {
             langBtn.addEventListener('click', function () {
                 var current = document.documentElement.getAttribute('lang') === 'es' ? 'es' : 'en';
-                setLang(current === 'es' ? 'en' : 'es');
+                var next = current === 'es' ? 'en' : 'es';
+                setLang(next);
+                logEvent('lang_toggle', { language: next });
             });
         }
 
@@ -248,6 +274,7 @@
             navToggle.addEventListener('click', function () {
                 var open = navMenu.classList.toggle('is-open');
                 navToggle.setAttribute('aria-expanded', String(open));
+                logEvent('mobile_nav_toggle', { action: open ? 'open' : 'close' });
             });
             // Close menu when tapping a link on mobile
             navMenu.addEventListener('click', function (e) {
@@ -271,5 +298,53 @@
         // Footer year
         var yearEl = $('#footer-year');
         if (yearEl) yearEl.textContent = String(new Date().getFullYear());
+
+        // ---------- Analytics: link tracking ----------
+
+        // Resume downloads
+        $$('a[href="resume/jd.pdf"]').forEach(function (link) {
+            link.addEventListener('click', function () {
+                logEvent('file_download', {
+                    file_name: 'jd.pdf',
+                    file_extension: 'pdf',
+                    link_location: link.closest('nav') ? 'nav' : 'hero'
+                });
+            });
+        });
+
+        // Section navigation
+        $$('.nav-menu a[href^="#"]').forEach(function (link) {
+            link.addEventListener('click', function () {
+                logEvent('select_content', {
+                    content_type: 'nav_section',
+                    content_id: link.getAttribute('href').substring(1)
+                });
+            });
+        });
+
+        // Contact links
+        $$('.contact-link').forEach(function (link) {
+            link.addEventListener('click', function () {
+                var href = link.getAttribute('href') || '';
+                var type = href.indexOf('mailto:') === 0 ? 'email'
+                         : href.indexOf('linkedin') > -1 ? 'linkedin'
+                         : href.indexOf('github') > -1   ? 'github'
+                         : 'other';
+                logEvent('select_content', {
+                    content_type: 'contact_link',
+                    content_id: type
+                });
+            });
+        });
+
+        // Google Play store link
+        $$('.store-btn--play').forEach(function (link) {
+            link.addEventListener('click', function () {
+                logEvent('select_content', {
+                    content_type: 'store_link',
+                    content_id: 'google_play_freshtrack'
+                });
+            });
+        });
     });
 })();


### PR DESCRIPTION
## Summary
- Integrate Firebase Analytics (GA4) via compat CDN SDK — no build step needed
- Automatic pageview tracking on every visit
- Custom event tracking for: resume downloads, section navigation, contact links (email/LinkedIn/GitHub), Google Play store link, theme toggle, language toggle, and mobile nav toggle
- Graceful degradation when SDK is blocked (ad blockers, `file://` previews)
- Firebase project: `jdgarita-site` (measurement ID: `G-NYVB5C810D`)

## Test plan
- [x] Verified Firebase SDK loads and initializes on `localhost:8000`
- [x] Confirmed user session visible in Firebase Console (Costa Rica)
- [x] Confirmed custom events appear in Firebase DebugView
- [ ] After merge, verify events flow on production `jdgarita.github.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)