### PR TITLE
Add Landing page button to FRNK project card

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -57,6 +57,8 @@
   "projects.store.availableOn": "Available on",
   "projects.store.comingSoon": "App Store — Coming soon",
   "projects.store.viewSourceOn": "View source on",
+  "projects.store.visit": "Visit",
+  "projects.store.landingPage": "Landing page",
   "skills.heading": "Tech stack",
   "skills.subheading": "",
   "skills.group.core": "Core",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,6 +5,8 @@
   "a11y.themeToggle": "Toggle light / dark theme",
   "a11y.langToggle": "Switch language",
   "a11y.menuToggle": "Toggle navigation menu",
+  "a11y.frnkLanding": "FRNK landing page",
+  "a11y.frnkSource": "FRNK source on GitHub",
   "nav.about": "About",
   "nav.experience": "Experience",
   "nav.projects": "Projects",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -7,6 +7,8 @@
   "a11y.themeToggle": "Cambiar tema claro / oscuro",
   "a11y.langToggle": "Cambiar idioma",
   "a11y.menuToggle": "Abrir menú de navegación",
+  "a11y.frnkLanding": "Landing page de FRNK",
+  "a11y.frnkSource": "Código fuente de FRNK en GitHub",
 
   "nav.about": "Sobre Mí",
   "nav.experience": "Experiencia",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -68,6 +68,8 @@
   "projects.store.availableOn": "Disponible en",
   "projects.store.comingSoon": "App Store — Próximamente",
   "projects.store.viewSourceOn": "Ver código en",
+  "projects.store.visit": "Visita",
+  "projects.store.landingPage": "Landing page",
 
   "skills.heading": "Stack técnico",
   "skills.subheading": "",

--- a/index.html
+++ b/index.html
@@ -228,8 +228,9 @@
                             <a class="store-btn store-btn--site"
                                href="https://jdgarita.github.io/frnk/"
                                target="_blank"
-                               rel="noopener"
-                               aria-label="FRNK landing page">
+                               rel="noopener noreferrer"
+                               aria-label="FRNK landing page"
+                               data-i18n-attr="aria-label:a11y.frnkLanding">
                                 <i class="fa fa-globe" aria-hidden="true"></i>
                                 <span class="store-btn-labels">
                                     <span class="store-btn-top" data-i18n="projects.store.visit">Visit</span>
@@ -240,8 +241,9 @@
                             <a class="store-btn store-btn--github"
                                href="https://github.com/jdgarita/frnk"
                                target="_blank"
-                               rel="noopener"
-                               aria-label="FRNK source on GitHub">
+                               rel="noopener noreferrer"
+                               aria-label="FRNK source on GitHub"
+                               data-i18n-attr="aria-label:a11y.frnkSource">
                                 <i class="fa fa-github" aria-hidden="true"></i>
                                 <span class="store-btn-labels">
                                     <span class="store-btn-top" data-i18n="projects.store.viewSourceOn">View source on</span>

--- a/index.html
+++ b/index.html
@@ -225,6 +225,18 @@
                         <p class="project-description" data-i18n="projects.frnk.description"></p>
 
                         <div class="project-stores">
+                            <a class="store-btn store-btn--site"
+                               href="https://jdgarita.github.io/frnk/"
+                               target="_blank"
+                               rel="noopener"
+                               aria-label="FRNK landing page">
+                                <i class="fa fa-globe" aria-hidden="true"></i>
+                                <span class="store-btn-labels">
+                                    <span class="store-btn-top" data-i18n="projects.store.visit">Visit</span>
+                                    <span class="store-btn-main" data-i18n="projects.store.landingPage">Landing page</span>
+                                </span>
+                            </a>
+
                             <a class="store-btn store-btn--github"
                                href="https://github.com/jdgarita/frnk"
                                target="_blank"

--- a/js/custom.js
+++ b/js/custom.js
@@ -34,6 +34,8 @@
             'a11y.themeToggle': 'Toggle light / dark theme',
             'a11y.langToggle': 'Switch language',
             'a11y.menuToggle': 'Toggle navigation menu',
+            'a11y.frnkLanding': 'FRNK landing page',
+            'a11y.frnkSource': 'FRNK source on GitHub',
             'nav.about': 'About',
             'nav.experience': 'Experience',
             'nav.projects': 'Projects',
@@ -107,6 +109,8 @@
             'a11y.themeToggle': 'Cambiar tema claro / oscuro',
             'a11y.langToggle': 'Cambiar idioma',
             'a11y.menuToggle': 'Abrir menú de navegación',
+            'a11y.frnkLanding': 'Landing page de FRNK',
+            'a11y.frnkSource': 'Código fuente de FRNK en GitHub',
             'nav.about': 'Sobre Mí',
             'nav.experience': 'Experiencia',
             'nav.projects': 'Proyectos',
@@ -347,31 +351,30 @@
             });
         });
 
-        // Google Play store link
+        // Project card outbound links — unified under one content_type so
+        // they group in GA4. content_id still distinguishes each target.
         $$('.store-btn--play').forEach(function (link) {
             link.addEventListener('click', function () {
                 logEvent('select_content', {
-                    content_type: 'store_link',
+                    content_type: 'project_link',
                     content_id: 'google_play_still'
                 });
             });
         });
 
-        // FRNK GitHub source link
         $$('.store-btn--github').forEach(function (link) {
             link.addEventListener('click', function () {
                 logEvent('select_content', {
-                    content_type: 'source_link',
+                    content_type: 'project_link',
                     content_id: 'github_frnk'
                 });
             });
         });
 
-        // FRNK landing page link
         $$('.store-btn--site').forEach(function (link) {
             link.addEventListener('click', function () {
                 logEvent('select_content', {
-                    content_type: 'site_link',
+                    content_type: 'project_link',
                     content_id: 'landing_frnk'
                 });
             });

--- a/js/custom.js
+++ b/js/custom.js
@@ -86,6 +86,8 @@
             'projects.store.availableOn': 'Available on',
             'projects.store.comingSoon': 'App Store — Coming soon',
             'projects.store.viewSourceOn': 'View source on',
+            'projects.store.visit': 'Visit',
+            'projects.store.landingPage': 'Landing page',
             'skills.heading': 'Tech stack',
             'skills.subheading': '',
             'skills.group.core': 'Core',
@@ -157,6 +159,8 @@
             'projects.store.availableOn': 'Disponible en',
             'projects.store.comingSoon': 'App Store — Próximamente',
             'projects.store.viewSourceOn': 'Ver código en',
+            'projects.store.visit': 'Visita',
+            'projects.store.landingPage': 'Landing page',
             'skills.heading': 'Stack técnico',
             'skills.subheading': '',
             'skills.group.core': 'Base',
@@ -359,6 +363,16 @@
                 logEvent('select_content', {
                     content_type: 'source_link',
                     content_id: 'github_frnk'
+                });
+            });
+        });
+
+        // FRNK landing page link
+        $$('.store-btn--site').forEach(function (link) {
+            link.addEventListener('click', function () {
+                logEvent('select_content', {
+                    content_type: 'site_link',
+                    content_id: 'landing_frnk'
                 });
             });
         });


### PR DESCRIPTION
## Summary
- Adds a **Visit / Landing page** button (left of the existing **View source on / GitHub** button) on the FRNK project card, linking to https://jdgarita.github.io/frnk/.
- Adds matching i18n keys (`projects.store.visit`, `projects.store.landingPage`) in `i18n/en.json`, `i18n/es.json`, and the `FALLBACK` dictionary in `js/custom.js`.
- Tracks clicks via Firebase Analytics with `select_content` / `content_id: 'landing_frnk'`.

## Test plan
- [ ] Serve locally (`python3 -m http.server 8000`) and open `#projects`
- [ ] Both buttons render side-by-side in the FRNK card; the new one is first
- [ ] Light + dark theme look correct
- [ ] EN ↔ ES toggle swaps "Visit / Landing page" ↔ "Visita / Landing page"
- [ ] The Landing page button opens https://jdgarita.github.io/frnk/ in a new tab
- [ ] Buttons wrap cleanly on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)