### PR TITLE
Point frnk link and docs to jdgarita.dev custom domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A plain static personal site for `jdgarita.github.io`, served by GitHub Pages directly from the repo root. `index.html` is the entry point; everything is hand-written vanilla HTML/CSS/JS. The only third-party CSS loaded is **FontAwesome 4.7.0** (vendored, for icons) and Google Fonts (Inter + JetBrains Mono). There is no Bootstrap, no jQuery, no build step, no package manager, no tests, no CI. Edits to the source files are the deliverable — open `index.html` in a browser to preview.
+A plain static personal site for `jdgarita.dev`, served by GitHub Pages directly from the repo root. `index.html` is the entry point; everything is hand-written vanilla HTML/CSS/JS. The only third-party CSS loaded is **FontAwesome 4.7.0** (vendored, for icons) and Google Fonts (Inter + JetBrains Mono). There is no Bootstrap, no jQuery, no build step, no package manager, no tests, no CI. Edits to the source files are the deliverable — open `index.html` in a browser to preview.
 
 Page sections, in order: Hero → About → Experience → Projects → Skills → Contact. Experience and Skills alternate on the `section-alt` background so the banding stays consistent.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# jdgarita.github.io
+# jdgarita.dev
 
 Personal landing page for **Juan Diego Garita** — Senior Android / Kotlin Multiplatform engineer.  
-Live at <https://jdgarita.github.io>.
+Live at <https://jdgarita.dev>.
 
 ## What it is
 

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
 
                         <div class="project-stores">
                             <a class="store-btn store-btn--site"
-                               href="https://jdgarita.github.io/frnk/"
+                               href="https://jdgarita.dev/frnk/"
                                target="_blank"
                                rel="noopener noreferrer"
                                aria-label="frnk landing page"


### PR DESCRIPTION
## What

The frnk project card's **landing page button** pointed at the old `https://jdgarita.github.io/frnk/` URL — broken/stale now that the site serves from the `jdgarita.dev` custom domain. This fixes it and syncs the remaining doc references.

## Changes

- `index.html` — frnk landing button `href` → `https://jdgarita.dev/frnk/`
- `README.md` — title and "Live at" URL → `jdgarita.dev`
- `CLAUDE.md` — site description reference → `jdgarita.dev`

No remaining `jdgarita.github.io` references in any tracked file. The GitHub Pages repo name is unchanged (it's served via the existing `CNAME`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)