### PR TITLE
docs: rename master to main, remove deploy instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,10 @@ A plain static personal site for `jdgarita.dev`, served by GitHub Pages directly
 
 Page sections, in order: Hero → About → Experience → Projects → Skills → Contact. Experience and Skills alternate on the `section-alt` background so the banding stays consistent.
 
-## Branches and deployment
+## Branches
 
-- `master` is the published branch. Pushing to `master` deploys via GitHub Pages.
+- `main` is the default branch.
 - `legacy` is the working branch for the 2026 redesign.
-- There is no deploy script; `git push` to `master` is the deploy.
 
 ## Repo layout
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Live at <https://jdgarita.dev>.
 
 ## What it is
 
-A single-page static site, hand-written in vanilla HTML, CSS, and JavaScript. No build step, no package manager, no framework, no tests, no CI. You edit the source files and push — GitHub Pages serves the repo root directly.
+A single-page static site, hand-written in vanilla HTML, CSS, and JavaScript. No build step, no package manager, no framework, no tests, no CI. You edit the source files directly.
 
 Features:
 
@@ -52,10 +52,6 @@ Elements reference keys via:
 ```
 
 When you add a new key, also mirror it in the `FALLBACK.en` / `FALLBACK.es` objects inside `js/custom.js` so `file://` previews keep working.
-
-## Deployment
-
-`master` is the published branch. `git push` to `master` is the deploy — there's no build or release script. The current redesign lives on `legacy`; merge to `master` to ship.
 
 ## Stack
 


### PR DESCRIPTION
## Summary
- Update `README.md` and `CLAUDE.md` to reflect the default-branch rename from `master` to `main`.
- Remove the deploy instructions from both docs (the "Deployment" section in `README.md`, the deploy lines in `CLAUDE.md`, and the "push — GitHub Pages serves the repo root" phrasing in the README intro) to keep the publish workflow private.

## Context
The remote default branch and GitHub Pages publishing source were already moved to `main` via the GitHub branch-rename API; this PR only updates the in-repo docs.

## Notes
- Kept the functional "served by GitHub Pages / local preview" context in `CLAUDE.md` since the agent needs it for path resolution and `fetch` behavior — only the *deploy* instructions were removed. Tell me if you want that stripped too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)