### PR TITLE
docs: correct API key restriction note in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Firebase Analytics (GA4 backend) is loaded via the **compat CDN** (v11.6.0) — 
 - Initialization and the `logEvent` helper live in `js/custom.js` inside the IIFE, guarded by `typeof firebase !== 'undefined'` so the site degrades gracefully if the SDK is blocked (ad blockers, `file://`).
 - Pageviews are tracked automatically on init.
 - Custom events: `file_download` (resume), `select_content` (nav sections, contact links, store link), `theme_toggle`, `lang_toggle`, `mobile_nav_toggle`.
-- The Firebase web API key is safe to commit — it's restricted by domain, not a secret.
+- The Firebase web API key is safe to commit — Firebase web keys identify the project and aren't secrets. The key (`Browser key (auto created by Firebase)`) is restricted by **API target** (which Google APIs it may call, e.g. `firebaseinstallations`), **not** by HTTP referrer/domain — so changing domains (e.g. → `jdgarita.dev`) does not break analytics.
 
 ## Icons
 


### PR DESCRIPTION
## What

Corrects the inaccurate `CLAUDE.md` note claiming the Firebase web API key is "restricted by domain."

## Why

While verifying Firebase Analytics after the move to the `jdgarita.dev` custom domain, an inspection of the project's `Browser key (auto created by Firebase)` showed:

- `browserKeyRestrictions: {}` — **no HTTP-referrer (domain) restriction at all**.
- Restriction is by **API target** instead (the list of Google APIs the key may call, including `firebaseinstallations.googleapis.com`, which the Analytics web SDK depends on).

This is why the domain move did **not** break analytics — confirmed live in GA4 (events arriving from `jdgarita.dev` today). The old wording was both inaccurate and misleading about why the migration was safe.

## Change

One line in the Analytics section of `CLAUDE.md`, clarifying that:
- Firebase web keys identify the project and aren't secrets.
- The key is restricted by API target, not HTTP referrer/domain.
- Changing domains does not break analytics.

Docs-only; no code or site behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)