### PR TITLE
content: host Still privacy policy & terms on /still/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,19 +10,19 @@ Page sections, in order: Hero → About → Experience → Projects → Skills �
 
 ## Branches
 
-- `main` is the default branch.
-- `legacy` is the working branch for the 2026 redesign.
+- `main` is the default branch and the only long-lived one. It is PR-protected — land changes via short-lived feature branches (e.g. `fix/…`, `docs/…`, `content/…`) merged through a PR, not by pushing directly to `main`. Merging to `main` is what deploys to GitHub Pages.
 
 ## Repo layout
 
 Tracked, load-bearing:
 - `index.html` — single-page site, all sections inline, semantic landmarks
 - `frnk/index.html` — sub-page for the frnk project, reuses the root `css/` and `js/`
+- `still/` — standalone legal mini-site for the **Still** app: `still/index.html` (hub) + `still/privacy-policy/` + `still/terms-and-conditions/`. Self-contained — its own `still/still.css`, **no** shared JS/i18n/analytics. See "Sub-pages" for why it deviates.
 - `css/custom.css` — token-driven stylesheet (CSS custom properties)
 - `js/custom.js` — theme toggle, language toggle, i18n loader, mobile nav
 - `i18n/en.json`, `i18n/es.json` — all user-visible copy (root + sub-pages share one dictionary)
 - `css/font-awesome.min.css` + `fonts/fontawesome-*` — FontAwesome 4.7.0 (includes `.woff2`)
-- `image/jd.png`, `image/frnk.png`, `image/android.ico` — profile photo, frnk logo, and favicon (sub-pages reference these via `../image/…`)
+- `image/jd.JPG`, `image/frnk.png`, `image/android.ico` — profile photo, frnk logo, and favicon (sub-pages reference these via `../image/…`). Note the **uppercase `.JPG`** on the profile photo: `index.html` references `image/jd.JPG` exactly, and GitHub Pages serves on a case-sensitive filesystem, so renaming it to `.jpg`/`.png` without updating the reference breaks the image in production even though it still works on macOS.
 - `resume/jd.pdf` — downloadable resume
 - `.github/workflows/claude-code-review.yml`, `claude.yml` — GitHub Actions that run Claude Code on PRs (no app-side CI)
 
@@ -57,12 +57,26 @@ Experience content comes from `resume/jd.pdf` — Swiftly, Mode, BodyBuilding.co
 
 ## Sub-pages
 
-Sub-pages (currently just `frnk/index.html`) reuse the root `css/custom.css` and `js/custom.js` so a single dictionary, theme, and analytics setup serve every page.
+There are **two** sub-page patterns. Pick the one that matches the page's purpose.
+
+### Shared-shell pattern (e.g. `frnk/index.html`)
+
+For project pages that should feel like part of the main site. They reuse the root `css/custom.css` and `js/custom.js` so a single dictionary, theme, and analytics setup serve every page.
 
 - Reference assets with relative paths: `../css/custom.css`, `../js/custom.js`, `../image/android.ico`.
 - Set `<html lang="…" data-i18n-base="../">` so `js/custom.js` resolves `fetch('../i18n/en.json')` instead of looking next to the sub-page.
 - Mirror the no-FOUC inline theme/lang script from the root `index.html` `<head>` so first paint matches.
 - Add new sub-page strings under a namespaced prefix in **both** `i18n/en.json` and `i18n/es.json` (e.g. `frnk.hero.title`), and mirror them in `FALLBACK.en` / `FALLBACK.es` inside `js/custom.js`.
+
+### Standalone pattern (`still/`)
+
+For content that should be **decoupled** from the main site — currently the **Still** app's legal mini-site (privacy policy, terms). These pages deliberately break the rules above, and that is intentional:
+
+- **Own stylesheet** (`still/still.css`), not `css/custom.css`. The "styles belong in `css/custom.css`" rule does **not** apply here — the mini-site owns its look so the personal site's palette can change independently.
+- **No i18n** — English-only, with the long-form legal prose inline in the HTML. The "route everything through i18n" rule does **not** apply: per-string dot-path keys are the wrong tool for multi-section legal documents.
+- **No analytics and no external JS.** The only script is a one-line inline stamp that keeps the footer copyright year current; it degrades to a literal year if JS is off. Light/dark follows the OS via `prefers-color-scheme` (no toggle).
+- **Clean URLs** come from directory + `index.html` (`still/privacy-policy/index.html` → `/still/privacy-policy`).
+- Contact / GDPR-controller email is `hello@jdgarita.dev`. Bump the `Effective date` in a page's `<head>` comment and body when its content changes.
 
 ## Theme & language toggles
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ css/font-awesome.min.css + fonts/fontawesome-*   FontAwesome 4.7.0 icons
 js/custom.js          theme toggle, language toggle, i18n loader, mobile nav
 i18n/en.json          English copy
 i18n/es.json          Spanish copy
-image/jd.png          profile photo
+image/jd.JPG          profile photo
 image/android.ico     favicon
 resume/jd.pdf         downloadable resume
+frnk/                 sub-page for the frnk project (shares root CSS/JS/i18n)
+still/                standalone legal mini-site for the Still app (own CSS, no JS/i18n)
 CLAUDE.md             notes for Claude Code sessions in this repo
 ```
 

--- a/still/index.html
+++ b/still/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!--
+      Still — legal hub (/still/)
+      ============================================================
+      Minimal landing page that links to the Still app's legal
+      documents. Standalone mini-site: own stylesheet (still.css),
+      no shared i18n/JS/analytics from the root site. English only.
+    -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Legal and privacy documents for Still, a food expiry tracker for Android and iOS." />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f1115" media="(prefers-color-scheme: dark)" />
+
+    <title>Still — Legal &amp; Privacy</title>
+    <link rel="canonical" href="https://jdgarita.dev/still/" />
+
+    <link rel="shortcut icon" href="../image/android.ico" />
+    <link rel="stylesheet" href="still.css" />
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <main class="container hub" id="main" tabindex="-1">
+        <p class="hub-eyebrow"><a href="../">← jdgarita.dev</a></p>
+        <h1>Still</h1>
+        <p class="hub-sub">Food expiry tracker for Android &amp; iOS — legal &amp; privacy documents.</p>
+
+        <nav class="hub-links" aria-label="Legal documents">
+            <a class="hub-card" href="privacy-policy/">
+                <span class="hub-card-title">Privacy Policy</span>
+                <span class="hub-card-desc">What data Still handles, and the choices you have.</span>
+            </a>
+            <a class="hub-card" href="terms-and-conditions/">
+                <span class="hub-card-title">Terms &amp; Conditions</span>
+                <span class="hub-card-desc">The terms that govern your use of the app.</span>
+            </a>
+        </nav>
+
+        <p class="hub-store">
+            <a href="https://play.google.com/store/apps/details?id=dev.jdgarita.freshtrack"
+               target="_blank" rel="noopener noreferrer">View Still on Google Play →</a>
+        </p>
+    </main>
+
+    <footer class="doc-footer">
+        <div class="container">
+            <p>© <span id="footer-year">2026</span> Juan Diego Garita</p>
+            <p><a href="mailto:hello@jdgarita.dev">hello@jdgarita.dev</a></p>
+        </div>
+    </footer>
+
+    <script>
+      // Keep the footer copyright year current — no external dependency.
+      var y = document.getElementById('footer-year');
+      if (y) { y.textContent = String(new Date().getFullYear()); }
+    </script>
+</body>
+</html>

--- a/still/privacy-policy/index.html
+++ b/still/privacy-policy/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!--
+      Still — Privacy Policy
+      ============================================================
+      Standalone legal page. Long-form prose is inline here by
+      design (NOT routed through the root site's per-string i18n
+      system, which is built for short UI labels). Own stylesheet,
+      no JS, follows OS light/dark via prefers-color-scheme.
+      When the policy changes, bump the "Effective date" below.
+    -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Privacy Policy for Still, a food expiry tracker for Android and iOS. The products and reminders you create stay on your device." />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f1115" media="(prefers-color-scheme: dark)" />
+
+    <title>Still — Privacy Policy</title>
+    <link rel="canonical" href="https://jdgarita.dev/still/privacy-policy/" />
+
+    <link rel="shortcut icon" href="../../image/android.ico" />
+    <link rel="stylesheet" href="../still.css" />
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="doc-header">
+        <div class="container">
+            <a class="wordmark" href="../">Still</a>
+            <nav class="doc-nav" aria-label="Legal documents">
+                <a href="../privacy-policy/" aria-current="page">Privacy Policy</a>
+                <a href="../terms-and-conditions/">Terms</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container doc" id="main" tabindex="-1">
+        <h1>Privacy Policy</h1>
+        <p class="doc-meta">Effective date: <time datetime="2026-05-15">May 15, 2026</time></p>
+
+        <h2>Overview</h2>
+        <p class="doc-lead">This Privacy Policy explains what data Still ("we", "us", "the app") handles, how it is used, and the choices you have. Still is a Kotlin Multiplatform mobile application for Android and iOS that helps you track product expiration dates and reminders.</p>
+        <p>Still is built around a simple principle: the products and reminders you create stay on your device. We do not run a server, we do not have a user account system, and we never receive the names, dates, or contents of the items you track.</p>
+        <p>The limited data we do receive (anonymous analytics on Android, subscription status from Google Play and RevenueCat) is described in detail below.</p>
+
+        <h2>1. Data You Create Stays on Your Device</h2>
+        <p>When you add products, set expiration dates, choose locations (fridge, freezer, pantry, etc.), or configure reminders, that information is stored only on your device:</p>
+        <ul>
+            <li>On Android, in a local SQLite database (<code>fresh_track.db</code>) and in SharedPreferences.</li>
+            <li>On iOS, in a local SQLite database (<code>fresh_track_v2.db</code>) and in NSUserDefaults.</li>
+        </ul>
+        <p>This data is not transmitted to Still or to any third party. We do not have a server that could store it.</p>
+        <p>If you uninstall the app, the operating system deletes this local data. On Android, your device may include Still's data in Google Play's automatic app backup if you have that feature enabled in your Google account; you can review or disable Auto Backup at <a href="https://developer.android.com/identity/data/autobackup" target="_blank" rel="noopener noreferrer">developer.android.com/identity/data/autobackup</a>.</p>
+
+        <h2>2. Subscriptions and Payments</h2>
+        <p>Still offers an optional Pro subscription. All subscription purchases, billing, renewals, and refunds are processed by Google Play under your Google account. We do not receive or store your payment details (card number, billing address, etc.).</p>
+        <p>To validate purchases and keep your Pro features unlocked across reinstalls and devices, we use RevenueCat as a third-party subscription and entitlement processor. When you make a subscription action in Still, RevenueCat receives:</p>
+        <ul>
+            <li>A randomly generated, anonymous app user ID (not linked to your name, email, or Google account in our records).</li>
+            <li>The purchase receipt provided by Google Play.</li>
+            <li>Your subscription / entitlement status (active, expired, in grace period, etc.).</li>
+            <li>Standard device metadata (platform, app version, country code).</li>
+        </ul>
+        <p>RevenueCat does not receive your name, your email address, or any of the products, dates, locations, or reminders you enter into Still.</p>
+        <p>RevenueCat's privacy practices are governed by their own privacy policy: <a href="https://www.revenuecat.com/privacy" target="_blank" rel="noopener noreferrer">revenuecat.com/privacy</a>.</p>
+        <p>You can restore previous purchases at any time from Settings &gt; Restore Purchases, and you can manage or cancel your subscription from Settings &gt; Manage Subscription.</p>
+
+        <h2>3. Analytics and Crash Reporting (Android Only)</h2>
+        <p>On Android, Still uses two services from Google.</p>
+        <p><strong>Firebase Analytics.</strong> We log anonymous, aggregated events about how the app is used so we can understand which features are useful and which ones need work. Examples of events we log:</p>
+        <ul>
+            <li>Screens you view (product list, settings, paywall, onboarding, archived products).</li>
+            <li>Product actions (added, updated, archived, restored, deleted).</li>
+            <li>Reminder actions (weekly reminder enabled or disabled, per-product reminder added, removed, or time changed).</li>
+            <li>Subscription events (paywall opened, purchase completed, purchases restored, manage-subscription tapped).</li>
+        </ul>
+        <p>Firebase Analytics does not receive the names, dates, or contents of the products you track, your email, or your name. Events are tied to a Google-generated app instance ID, not to a personal identifier.</p>
+        <p><strong>Firebase Crashlytics.</strong> When the app crashes or hits an unexpected error, Crashlytics records non-personal diagnostic information so we can fix the bug — typically the stack trace, the device model, the operating system version, and the Still app version. It does not capture the contents of the screen you were on or the products you had entered.</p>
+        <p>The iOS version of Still does not currently use Firebase Analytics or Crashlytics. Nothing is sent to any analytics or crash-reporting service from iOS.</p>
+        <p>Google's handling of Firebase data is governed by the Firebase Privacy and Security policy: <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener noreferrer">firebase.google.com/support/privacy</a>. You can opt out of Google Analytics on Android via your device's Google account settings.</p>
+
+        <h2>4. Reminders and Notifications</h2>
+        <p>Still can send local notifications to remind you about expiring products — both a weekly digest (free and Pro) and per-product reminders (Pro only).</p>
+        <p>All reminder scheduling is performed on your device using the operating system's notification system. The content of every reminder (the product name, expiration text, etc.) stays on the device and is never sent to us or to any third party. We do not run a server that could receive or trigger your reminders.</p>
+        <p>To deliver these notifications, Still uses operating system permissions:</p>
+        <ul>
+            <li>Android 13 (Tiramisu) and above: the app requests the POST_NOTIFICATIONS runtime permission so it can show notifications, and it uses the system's exact-alarm scheduling so reminders fire at the time you choose.</li>
+            <li>Android (all versions): a boot receiver re-schedules pending reminders after your device restarts so you don't miss them.</li>
+            <li>iOS: the app requests notification authorization (alerts and sound) the first time you enable reminders.</li>
+        </ul>
+        <p>You can disable reminders at any time from Still Settings, or revoke the system notification permission from your device's settings app.</p>
+
+        <h2>5. How We Use the Data We Receive</h2>
+        <p>Beyond the data that stays on your device, the limited information we (or our processors on our behalf) receive is used only to:</p>
+        <ul>
+            <li>Validate and entitle your subscription (Google Play, RevenueCat).</li>
+            <li>Diagnose crashes and bugs (Firebase Crashlytics, Android only).</li>
+            <li>Understand how the app is used in aggregate so we can improve it (Firebase Analytics, Android only).</li>
+        </ul>
+        <p>We do not sell this data. We do not use it for advertising. We do not share it with third parties beyond the processors named in this policy (Google and RevenueCat) and as required by law.</p>
+
+        <h2>6. Third-Party Services We Rely On</h2>
+        <div class="svc">
+            <h3>Google Play Billing</h3>
+            <ul>
+                <li>Purpose: Subscription billing and refunds.</li>
+                <li>Platforms: Android.</li>
+                <li>Privacy policy: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">policies.google.com/privacy</a></li>
+            </ul>
+        </div>
+        <div class="svc">
+            <h3>RevenueCat</h3>
+            <ul>
+                <li>Purpose: Subscription validation and entitlements.</li>
+                <li>Platforms: Android, iOS.</li>
+                <li>Privacy policy: <a href="https://www.revenuecat.com/privacy" target="_blank" rel="noopener noreferrer">revenuecat.com/privacy</a></li>
+            </ul>
+        </div>
+        <div class="svc">
+            <h3>Firebase Analytics</h3>
+            <ul>
+                <li>Purpose: Anonymous usage analytics.</li>
+                <li>Platforms: Android only.</li>
+                <li>Privacy policy: <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener noreferrer">firebase.google.com/support/privacy</a></li>
+            </ul>
+        </div>
+        <div class="svc">
+            <h3>Firebase Crashlytics</h3>
+            <ul>
+                <li>Purpose: Crash and error reporting.</li>
+                <li>Platforms: Android only.</li>
+                <li>Privacy policy: <a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener noreferrer">firebase.google.com/support/privacy</a></li>
+            </ul>
+        </div>
+
+        <h2>7. Data Retention</h2>
+        <ul>
+            <li>On-device data (your products, settings, reminders) is retained as long as Still is installed. Uninstalling the app deletes it from the device. It may also be included in Android's Google Auto Backup if you have that enabled in your Google account.</li>
+            <li>Subscription records held by Google Play and RevenueCat are retained per their respective policies and are required for billing, refunds, and entitlement validation.</li>
+            <li>Analytics and crash data sent to Firebase (Android only) are retained according to Google's Firebase data retention policy.</li>
+        </ul>
+        <p>Because Still does not have an account system, there is no Still account to delete. To remove your local data, uninstall the app. To remove subscription records, contact Google Play or RevenueCat directly.</p>
+
+        <h2>8. Children's Privacy</h2>
+        <p>Still is not directed to children under the age of 13, and we do not knowingly collect personally identifiable information from anyone under 13. If you believe we have inadvertently received such information, please contact us at the address below and we will take steps to address it.</p>
+
+        <h2>9. Your Rights — GDPR (European Union / EEA / United Kingdom)</h2>
+        <p>If you are located in the European Union, the European Economic Area, or the United Kingdom, the General Data Protection Regulation (GDPR) and equivalent UK legislation give you specific rights over your personal data.</p>
+        <p><strong>Data controller.</strong> The data controller for Still is Juan Diego Garita. You can reach the controller at the contact email below.</p>
+        <p><strong>Legal bases.</strong> Where GDPR applies, our legal bases for processing are:</p>
+        <ul>
+            <li>Your consent — for analytics and crash reporting on Android, which you can opt out of via your device's Google settings.</li>
+            <li>Performance of a contract or legitimate interest — for processing your subscription via Google Play and RevenueCat so we can deliver the Pro features you requested, and for scheduling the local reminders you set up.</li>
+        </ul>
+        <p><strong>Your rights.</strong> You have the right to access, rectify, erase, restrict, port, or object to the processing of your personal data, and to withdraw consent at any time. Because most of your data lives only on your device, the most direct way to exercise these rights is to manage the data in the app or to uninstall.</p>
+        <p><strong>Right to lodge a complaint.</strong> You may also lodge a complaint with your local data protection supervisory authority.</p>
+
+        <h2>10. Your Rights — CCPA (California)</h2>
+        <p>If you are a California resident, the California Consumer Privacy Act (CCPA) gives you specific rights:</p>
+        <ul>
+            <li><strong>Right to know.</strong> You can ask us what categories of personal information we have received about you. The categories described in this policy (anonymous analytics on Android, subscription metadata via RevenueCat) are the only categories that apply.</li>
+            <li><strong>Right to delete.</strong> You can ask us to delete personal information we hold about you. Most of the data described here is held by Google or RevenueCat, not by us — see those services for direct deletion options.</li>
+            <li><strong>Right to opt out of sale.</strong> We do not sell the personal information of our users.</li>
+            <li><strong>Right to non-discrimination.</strong> We will not discriminate against you for exercising any CCPA right.</li>
+        </ul>
+        <p>To make a CCPA request, contact us at the email below.</p>
+
+        <h2>11. Changes to This Privacy Policy</h2>
+        <p>We may update this Privacy Policy as the app evolves. The "Effective date" at the top of this page reflects the most recent revision. Material changes will be reflected in the in-app Settings link and on this page.</p>
+
+        <h2>12. Contact</h2>
+        <p>If you have questions about this Privacy Policy or how Still handles your data:</p>
+        <p>Email: <a href="mailto:hello@jdgarita.dev">hello@jdgarita.dev</a></p>
+    </main>
+
+    <footer class="doc-footer">
+        <div class="container">
+            <p>© <span id="footer-year">2026</span> Juan Diego Garita</p>
+            <p><a href="../terms-and-conditions/">Terms &amp; Conditions</a> · <a href="../">Still</a></p>
+        </div>
+    </footer>
+
+    <script>
+      // Keep the footer copyright year current — no external dependency.
+      var y = document.getElementById('footer-year');
+      if (y) { y.textContent = String(new Date().getFullYear()); }
+    </script>
+</body>
+</html>

--- a/still/still.css
+++ b/still/still.css
@@ -1,0 +1,295 @@
+/*
+  Still — legal pages stylesheet
+  ============================================================
+  Self-contained, neutral styling for the Still app's legal
+  documents (privacy policy, terms). Intentionally NOT coupled
+  to the root site's css/custom.css: the Still mini-site owns
+  its own look, so changing jdgarita.dev's palette never alters
+  these pages and vice versa.
+
+  No JavaScript and no web fonts — these pages follow the OS
+  light/dark preference via prefers-color-scheme and use the
+  system font stack so they load instantly and offline.
+*/
+
+:root {
+  --bg:        #ffffff;
+  --surface:   #ffffff;
+  --surface-2: #f6f7f9;
+  --text:      #161a1f;
+  --muted:     #5b6470;
+  --accent:    #2563eb;
+  --accent-2:  #1d4ed8;
+  --border:    #e4e7ec;
+  --ring:      #2563eb;
+
+  --maxw: 720px;
+  --radius: 12px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0f1115;
+    --surface:   #14171c;
+    --surface-2: #1a1e25;
+    --text:      #e6e8ec;
+    --muted:     #9aa3af;
+    --accent:    #6ea8fe;
+    --accent-2:  #93c0ff;
+    --border:    #262b33;
+    --ring:      #6ea8fe;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 17px;
+  line-height: 1.65;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+.container {
+  width: 100%;
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+/* ---------- Skip link ---------- */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background: var(--accent);
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 0 0 var(--radius) 0;
+  z-index: 10;
+}
+.skip-link:focus {
+  left: 0;
+}
+
+/* ---------- Header ---------- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.doc-header .container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 20px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+.wordmark {
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  text-decoration: none;
+}
+.wordmark:hover { color: var(--accent); }
+
+.doc-nav {
+  margin-left: auto;
+  display: flex;
+  gap: 18px;
+  font-size: 0.95rem;
+}
+.doc-nav a {
+  color: var(--muted);
+  text-decoration: none;
+}
+.doc-nav a:hover { color: var(--accent); }
+.doc-nav a[aria-current="page"] {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---------- Document body ---------- */
+main.doc {
+  padding-top: 40px;
+  padding-bottom: 64px;
+}
+.doc h1 {
+  font-size: 2rem;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.doc-meta {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin: 0 0 8px;
+}
+.doc-lead {
+  font-size: 1.05rem;
+  color: var(--text);
+  margin: 16px 0 0;
+}
+.doc h2 {
+  font-size: 1.3rem;
+  letter-spacing: -0.01em;
+  margin: 40px 0 12px;
+  padding-top: 8px;
+}
+.doc h3 {
+  font-size: 1.05rem;
+  margin: 28px 0 10px;
+}
+.doc p { margin: 0 0 16px; }
+.doc ul {
+  margin: 0 0 16px;
+  padding-left: 22px;
+}
+.doc li { margin: 0 0 8px; }
+.doc a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+.doc a:hover { color: var(--accent-2); }
+.doc code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 1px 5px;
+}
+
+/* Definition-style block for the third-party services list */
+.svc {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  padding: 16px 18px;
+  margin: 0 0 14px;
+}
+.svc h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+.svc ul { margin: 0; }
+.svc li { margin: 0 0 4px; }
+
+/* ---------- Footer ---------- */
+.doc-footer {
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.doc-footer .container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 20px;
+  justify-content: space-between;
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+.doc-footer p { margin: 0; }
+.doc-footer a { color: var(--muted); }
+.doc-footer a:hover { color: var(--accent); }
+
+/* ---------- Hub (/still/) ---------- */
+main.hub {
+  padding-top: 64px;
+  padding-bottom: 72px;
+}
+.hub-eyebrow {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+}
+.hub-eyebrow a {
+  color: var(--muted);
+  text-decoration: none;
+}
+.hub-eyebrow a:hover { color: var(--accent); }
+.hub h1 {
+  font-size: 2.4rem;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+.hub-sub {
+  color: var(--muted);
+  font-size: 1.05rem;
+  margin: 0 0 32px;
+}
+.hub-links {
+  display: grid;
+  gap: 14px;
+  margin: 0 0 28px;
+}
+.hub-card {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  padding: 18px 20px;
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.hub-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+.hub-card-title {
+  display: block;
+  font-weight: 600;
+  font-size: 1.1rem;
+  margin-bottom: 2px;
+}
+.hub-card-desc {
+  display: block;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+.hub-store { margin: 0; font-size: 0.95rem; }
+.hub-store a { color: var(--accent); text-decoration: none; }
+.hub-store a:hover { text-decoration: underline; }
+
+/* ---------- Focus ring (do not remove outlines) ---------- */
+a:focus-visible,
+.hub-card:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* Skip-link target: <main> carries tabindex="-1" so the skip link
+   reliably moves focus in Safari/Firefox, but the content container
+   itself should not draw a focus ring. Interactive controls keep theirs. */
+main[tabindex="-1"] {
+  outline: none;
+}
+
+/* ---------- Small screens ---------- */
+@media (max-width: 480px) {
+  body { font-size: 16px; }
+  .doc h1 { font-size: 1.6rem; }
+  .hub h1 { font-size: 2rem; }
+  .doc-nav { gap: 14px; }
+}
+
+/* ---------- Print ---------- */
+@media print {
+  .doc-header, .doc-footer, .skip-link { display: none; }
+  body { font-size: 12pt; color: #000; background: #fff; }
+  .doc a { color: #000; text-decoration: underline; }
+  main.doc { padding-top: 0; }
+}

--- a/still/terms-and-conditions/index.html
+++ b/still/terms-and-conditions/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!--
+      Still — Terms and Conditions
+      ============================================================
+      Standalone legal page. Long-form prose is inline here by
+      design (NOT routed through the root site's per-string i18n
+      system, which is built for short UI labels). Own stylesheet,
+      no JS, follows OS light/dark via prefers-color-scheme.
+      When the terms change, bump the "Effective date" below.
+    -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="Terms and Conditions for Still, a food expiry tracker for Android and iOS." />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f1115" media="(prefers-color-scheme: dark)" />
+
+    <title>Still — Terms and Conditions</title>
+    <link rel="canonical" href="https://jdgarita.dev/still/terms-and-conditions/" />
+
+    <link rel="shortcut icon" href="../../image/android.ico" />
+    <link rel="stylesheet" href="../still.css" />
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="doc-header">
+        <div class="container">
+            <a class="wordmark" href="../">Still</a>
+            <nav class="doc-nav" aria-label="Legal documents">
+                <a href="../privacy-policy/">Privacy Policy</a>
+                <a href="../terms-and-conditions/" aria-current="page">Terms</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container doc" id="main" tabindex="-1">
+        <h1>Terms and Conditions</h1>
+        <p class="doc-meta">Effective date: <time datetime="2026-05-15">May 15, 2026</time></p>
+
+        <h2>1. Acceptance of These Terms</h2>
+        <p class="doc-lead">These Terms and Conditions ("Terms") govern your use of the Still mobile application for Android and iOS ("Still", "the app", "we", "us"). By downloading, installing, or using Still, you agree to be bound by these Terms. If you do not agree, do not use the app.</p>
+        <p>These Terms should be read together with the Still Privacy Policy at <a href="../privacy-policy/">https://jdgarita.dev/still/privacy-policy</a>, which describes how the app handles data.</p>
+
+        <h2>2. License to Use the App</h2>
+        <p>We grant you a personal, non-exclusive, non-transferable, revocable license to download and use Still on devices that you own or control, solely for your personal, non-commercial use, in accordance with these Terms and the rules of the app store from which you obtained the app (Google Play or the Apple App Store).</p>
+        <p>You may not:</p>
+        <ul>
+            <li>License, sell, rent, lease, sublicense, distribute, or otherwise transfer the app to any third party.</li>
+            <li>Modify, translate, adapt, merge, or create derivative works of the app, except as expressly permitted by applicable law.</li>
+            <li>Reverse engineer, decompile, disassemble, or otherwise attempt to derive the source code of the app, except as expressly permitted by applicable law.</li>
+            <li>Remove, alter, or obscure any proprietary notices (including copyright and trademark notices) on or in the app.</li>
+            <li>Use the app for any unlawful purpose, or in a way that interferes with the rights of others or the operation of the app.</li>
+        </ul>
+
+        <h2>3. Account and Data</h2>
+        <p>Still does not require you to create an account. The products, locations, expiration dates, and reminders you enter are stored locally on your device. You are responsible for maintaining backups of any data that is important to you. If you uninstall the app, your local data will be removed by the operating system. See the <a href="../privacy-policy/">Privacy Policy</a> for details.</p>
+
+        <h2>4. Subscriptions, Billing, Cancellation, and Refunds</h2>
+
+        <h3>4.1 Pro subscription</h3>
+        <p>Still offers an optional Pro subscription that unlocks additional features (such as per-product reminders). The available subscription plans (e.g. monthly, annual), the current price, and the billing period are shown on the in-app paywall before you confirm any purchase.</p>
+        <p>All subscription purchases are processed by Google Play through your Google account. We do not directly receive or store your payment details.</p>
+
+        <h3>4.2 Auto-renewal</h3>
+        <p>Subscriptions are auto-renewing. Unless you cancel at least 24 hours before the end of the current billing period, your subscription will automatically renew at the end of that period at the then-current price for the same plan. Your Google Play account will be charged at confirmation of purchase and again at each renewal.</p>
+        <p>You will see the renewal price and date in your Google Play subscription settings before any renewal charge.</p>
+
+        <h3>4.3 Cancellation</h3>
+        <p>You can cancel your subscription at any time:</p>
+        <ul>
+            <li>From inside Still: Settings &gt; Manage Subscription (this opens your Google Play subscription page).</li>
+            <li>Directly on the web: <a href="https://play.google.com/store/account/subscriptions" target="_blank" rel="noopener noreferrer">play.google.com/store/account/subscriptions</a></li>
+        </ul>
+        <p>Cancellation takes effect at the end of the current billing period. You will retain Pro access until then, and you will not be charged again after the cancellation takes effect.</p>
+
+        <h3>4.4 Refunds</h3>
+        <p>Refunds for subscription purchases are handled by Google Play under their refund policy: <a href="https://support.google.com/googleplay/answer/2479637" target="_blank" rel="noopener noreferrer">support.google.com/googleplay/answer/2479637</a></p>
+        <p>Because Google Play processes the payment, Still cannot directly issue refunds for subscription charges. If you believe you are eligible for a refund, request it through Google Play.</p>
+        <p>If you have a non-billing concern about Still itself, contact us at the email below and we will work with you to address it.</p>
+
+        <h3>4.5 Restore purchases</h3>
+        <p>If you reinstall Still, switch devices, or sign in with a different Google account, you can re-validate your active subscription by tapping Settings &gt; Restore Purchases. This uses Google Play and our subscription processor (RevenueCat) to look up your existing entitlement and unlock Pro features.</p>
+
+        <h3>4.6 Free trials and introductory offers</h3>
+        <p>If Still offers a free trial or introductory price for a subscription, the conditions (length of trial, price after the trial, etc.) will be shown on the paywall before you start. A free trial automatically converts into a paid subscription at the end of the trial period unless you cancel beforehand. Cancellation works the same way as described in section 4.3.</p>
+
+        <h3>4.7 Price changes</h3>
+        <p>We may change the price of subscription plans for new purchases at any time. For existing subscribers, any price change for a renewal will be communicated by Google Play in accordance with their policies, and you will have the opportunity to accept the new price or cancel before it takes effect.</p>
+
+        <h2>5. Intellectual Property</h2>
+        <p>Still, including its design, code, content, logos, and trademarks, is owned by Juan Diego Garita and is protected by copyright, trademark, and other intellectual property laws. These Terms grant you a license to use the app — they do not transfer any ownership of the app or its content to you.</p>
+
+        <h2>6. Disclaimers</h2>
+        <p>Still is provided "AS IS" and "AS AVAILABLE", with all faults and defects, and without warranty of any kind, whether express, implied, statutory, or otherwise, including (without limitation) implied warranties of merchantability, fitness for a particular purpose, title, and non-infringement. We do not warrant that the app will be uninterrupted, error-free, secure, or free of viruses.</p>
+        <p>Still is a productivity tool, not a food safety, medical, or pharmaceutical service. Expiration dates you enter into the app are not verified by us. Reminder notifications depend on operating system features (background scheduling, exact alarms, notification delivery) that can be delayed or suppressed by the operating system, by power-saving modes, or by user-granted permissions. Do not rely on Still as the sole or primary source of truth for food safety, medication management, or any other situation where missing or incorrect information could cause harm. Always inspect items in person and follow the safety guidance of the manufacturer or a qualified professional.</p>
+
+        <h2>7. Limitation of Liability</h2>
+        <p>To the maximum extent permitted by applicable law, in no event will Still, Juan Diego Garita, or our suppliers and licensors be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits, revenues, data, or goodwill, arising out of or in connection with your use of (or inability to use) the app, even if we have been advised of the possibility of such damages.</p>
+        <p>To the maximum extent permitted by applicable law, our total aggregate liability arising out of or relating to these Terms or your use of the app will not exceed the amount you paid to us (through Google Play) for Still subscriptions in the twelve (12) months preceding the event giving rise to the claim, or USD $50, whichever is greater.</p>
+        <p>Some jurisdictions do not allow certain limitations of liability, so some of the above may not apply to you.</p>
+
+        <h2>8. Termination</h2>
+        <p>You can stop using Still and uninstall the app at any time. We may suspend or terminate your access to the app, or stop providing the app, at any time, with or without cause and with or without notice, including (without limitation) if you violate these Terms or if continued provision becomes commercially or legally impractical.</p>
+        <p>If your access is terminated, you remain responsible for any subscription charges already incurred. Cancellation of a subscription does not automatically terminate the app — you may continue to use the free features.</p>
+
+        <h2>9. Governing Law and Dispute Resolution</h2>
+
+        <h3>9.1 Governing law</h3>
+        <p>These Terms, and any dispute arising out of or related to them or to your use of Still, are governed by the laws of the Republic of Costa Rica, without regard to its conflict of laws principles, except as required by mandatory consumer protection laws of your country of residence.</p>
+
+        <h3>9.2 Informal resolution</h3>
+        <p>Before filing a formal claim, you agree to first contact us at the email below and attempt to resolve the dispute informally for a period of at least sixty (60) days.</p>
+
+        <h3>9.3 Arbitration</h3>
+        <p>If the dispute cannot be resolved informally within sixty (60) days, both you and we agree that the dispute will be resolved by binding individual arbitration under the rules of the American Arbitration Association (AAA), and not by court trial, except where such an arbitration agreement is unenforceable under your local law. You and we waive any right to a jury trial and to participate in a class action, to the extent permitted by law.</p>
+        <p>If arbitration is unenforceable in your jurisdiction, the dispute will be resolved by the competent courts of San José, Costa Rica.</p>
+
+        <h2>10. Changes to These Terms</h2>
+        <p>We may update these Terms from time to time. The "Effective date" at the top of this page reflects the most recent revision. If we make material changes, we will surface them in the app or otherwise provide reasonable notice. Your continued use of Still after the changes take effect constitutes acceptance of the updated Terms.</p>
+
+        <h2>11. Severability</h2>
+        <p>If any provision of these Terms is held to be invalid or unenforceable, that provision will be enforced to the maximum extent permitted, and the remaining provisions will remain in full force and effect.</p>
+
+        <h2>12. Contact</h2>
+        <p>For questions about these Terms or about Still:</p>
+        <p>Email: <a href="mailto:hello@jdgarita.dev">hello@jdgarita.dev</a></p>
+    </main>
+
+    <footer class="doc-footer">
+        <div class="container">
+            <p>© <span id="footer-year">2026</span> Juan Diego Garita</p>
+            <p><a href="../privacy-policy/">Privacy Policy</a> · <a href="../">Still</a></p>
+        </div>
+    </footer>
+
+    <script>
+      // Keep the footer copyright year current — no external dependency.
+      var y = document.getElementById('footer-year');
+      if (y) { y.textContent = String(new Date().getFullYear()); }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Moves the **Still** app's legal documents off Google Sites and onto `jdgarita.dev`, so the URLs are owned, stable, and free to host.

## What's added
| URL | File |
|---|---|
| `jdgarita.dev/still` | `still/index.html` — minimal legal hub |
| `jdgarita.dev/still/privacy-policy` | `still/privacy-policy/index.html` |
| `jdgarita.dev/still/terms-and-conditions` | `still/terms-and-conditions/index.html` |
| — | `still/still.css` — self-contained stylesheet |

## Approach
- **Standalone mini-site**, intentionally *not* the shared-shell sub-page pattern (`frnk/`): own stylesheet, **no** shared CSS/JS, **no** i18n (English-only, prose inline), **no** analytics. Long-form legal text is a poor fit for the per-string i18n dictionary, and the mini-site owns its own look so the personal site's palette can change independently.
- **Clean URLs** via directory + `index.html`. Auto light/dark via `prefers-color-scheme` (no toggle, JS-free apart from a one-line footer-year stamp).
- Documented the new standalone pattern in `CLAUDE.md` + `README.md`.

## Content changes during the port (text otherwise verbatim)
- Contact + GDPR-controller email → `hello@jdgarita.dev`.
- Fixed the **broken Terms→Privacy cross-link** (it referenced a non-existent `still-privacy-policy` Google Site) → now the new canonical URL.
- Effective date kept at **May 15, 2026** (substance unchanged).

## Quality
- All pages return `200`; extensionless → trailing-slash `301` (matches GitHub Pages).
- A11y: semantic landmarks, skip link with focusable `<main>`, `aria-current`, `:focus-visible` rings, AA contrast both themes.
- Security: every `target="_blank"` has `rel="noopener noreferrer"`; no input/secret/injection surface.
- Valid UTF-8; `<link rel="canonical">` + `<time datetime>` on each doc.

## ⚠️ Before/after merge (outside this repo)
- [ ] Confirm **`hello@jdgarita.dev` is a live inbox** — it's now the GDPR/CCPA/support contact.
- [ ] Repoint the Still app's in-app Settings links, the **Google Play** listing privacy URL, and **App Store Connect** privacy URL to the new `jdgarita.dev/still/...` URLs.
- [ ] Then unpublish the old Google Sites pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)